### PR TITLE
Convert legacy add-on to extension

### DIFF
--- a/build.py
+++ b/build.py
@@ -2,26 +2,24 @@
 # This file is part of 0 A.D.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-import ast, os, zipfile
+import os
+import tomllib
+import zipfile
+
 
 def get_version():
-    with open("io_scene_pyrogenesis/__init__.py", "r", encoding='UTF-8') as f:
-        data = f.read()
+    with open("io_scene_pyrogenesis/blender_manifest.toml", "rb") as f:
+        manifest = tomllib.load(f)
+        return manifest["version"]
 
-    ast_data = ast.parse(data)
-    for node in ast_data.body:
-        if node.__class__ == ast.Assign:
-            if len(node.targets) == 1:
-                if getattr(node.targets[0], "id", "") == "bl_info":
-                    break
-    version = ast.literal_eval(node.value)["version"]
-    return str(version[0]) + '.' + str(version[1]) + '.' + str(version[2])
 
 def build_archive():
     os.makedirs("dist", exist_ok=True)
     with zipfile.ZipFile(os.path.join("dist", "io_scene_pyrogenesis-" + get_version() + ".zip"), mode="w") as archive:
         archive.write("io_scene_pyrogenesis/__init__.py")
+        archive.write("io_scene_pyrogenesis/blender_manifest.toml")
         archive.write("LICENSE", arcname="io_scene_pyrogenesis/LICENSE")
+
 
 if __name__ == '__main__':
     build_archive()

--- a/io_scene_pyrogenesis/__init__.py
+++ b/io_scene_pyrogenesis/__init__.py
@@ -4,22 +4,6 @@
 
 # 'https://blender.stackexchange.com/questions/39303/blender-script-import-model-and-render-it'
 
-
-bl_info = {
-    'name': 'Blender Pyrogenesis Importer',
-    'author': 'Stanislas Daniel Claude Dolcini',
-    'version': (1, 3, 13),
-    'blender':  (2, 90, 3),
-    'location': 'File > Import-Export',
-    'description': 'Import ',
-    'wiki_url': 'https://github.com/StanleySweet/blender_pyrogenesis_importer',
-    'category': 'Import-Export'
-}
-
-def get_version_string():
-    return str(bl_info['version'][0]) + '.' + str(bl_info['version'][1]) + '.' + str(bl_info['version'][2])
-
-
 #
 # Script reloading (if the user calls 'Reload Scripts' from Blender)
 #

--- a/io_scene_pyrogenesis/__init__.py
+++ b/io_scene_pyrogenesis/__init__.py
@@ -199,11 +199,7 @@ class ImportPyrogenesisActor(bpy.types.Operator, ImportHelper):
 
             if texture.split('|')[0] == 'specTex':
                 texImage.image.colorspace_settings.name='Non-Color'
-                if bpy.app.version < (4, 0, 0):
-                    mat.node_tree.links.new(bsdf.inputs['Specular'], texImage.outputs['Color'])
-                else:
-                    mat.node_tree.links.new(bsdf.inputs['Specular IOR Level'], texImage.outputs['Color'])
-                continue
+                mat.node_tree.links.new(bsdf.inputs['Specular IOR Level'], texImage.outputs['Color'])
 
         return mat.name
 

--- a/io_scene_pyrogenesis/blender_manifest.toml
+++ b/io_scene_pyrogenesis/blender_manifest.toml
@@ -1,0 +1,16 @@
+schema_version = "1.0.0"
+
+version = "2.0.0"
+blender_version_min = "4.2.0"
+
+id = "io_scene_pyrogenesis"
+name = "Blender Pyrogenesis Importer"
+tagline = "Import Pyrogenesis Actors into Blender"
+maintainer = "Stanislas Daniel Claude Dolcini <stanislas.dolcini@devinci.fr>"
+type = "add-on"
+website = "https://github.com/StanleySweet/blender_pyrogenesis_importer"
+tags = ["Import-Export"]
+license = ["SPDX:GPL-2.0-or-later"]
+
+[permissions]
+files = "Fixup Maya dae and import pyrogenesis actors from disk"

--- a/readme.md
+++ b/readme.md
@@ -1,19 +1,32 @@
 # Blender Pyrogenesis Importer
 
-Blender plugin to import models from the game 0ad using pyrogenesis
+Blender extension to import models from the game 0ad using pyrogenesis
+
+> [!NOTE]
+> For Blender versions before 4.2 use the legacy add-on with version 1.x
 
 ## Build
 
-    python3 build.py
+```sh
+python3 build.py
+```
+
+Alternatively using Blender 4.2+
+
+```sh
+cd io_scene_pyrogenesis
+blender --command extension build
+```
 
 ## Installation
-1. Build or download the latest release of io_scene_pyrogenesis.zip
-2. In Blender, navigate to **Edit > Preferences... > Add-ons** and install the ZIP with the **Install...** button).
-3. Type 'pyrogenesis' in the search bar and tick the checkbox next to **Import-Export: Blender Pyrogenesis Importer** to enable it.
 
-You can now import pyrogenesis xml actor files with **File > Import > Pyrogenesis Actor (.xml)*.
+1. Build or download the latest release of io_scene_pyrogenesis.zip
+2. In Blender, navigate to **Edit > Preferences... > Get Extensions** and in the dropdown menu in the top right corner select **Install from Disk...**
+
+You can now import pyrogenesis xml actor files with **File > Import > Pyrogenesis Actor (.xml)**.
 
 ## Unsupported Features
-* Animation Import
-* 3Dsmax Animation Import
-* Multiple armatures with the same name
+
+- Animation Import
+- 3Dsmax Animation Import
+- Multiple armatures with the same name


### PR DESCRIPTION
Blender 4.2 deprecated add-on in favor of their new extension platform https://extensions.blender.org/

This patch series should be the minimum required for submitting it for inclusion on above mentioned platform.